### PR TITLE
fixed macOS build

### DIFF
--- a/SlackLogViewer/CMakeLists.txt
+++ b/SlackLogViewer/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(
     
 install(TARGETS ${PROJECT_NAME}
         EXPORT ${MY_PACKAGE_NAME}Targets
+        BUNDLE DESTINATION ./
         RUNTIME DESTINATION ./)
 
 include(DeployQt.cmake)
@@ -83,7 +84,7 @@ install(DIRECTORY DESTINATION "Cache")
 # std::execution::par might require TBB
 find_package(TBB)
 if(TBB_FOUND)
-    target_link_libraries(${PROJECT_NAME} PRIVATE tbb)
+    target_link_libraries(${PROJECT_NAME} PRIVATE TBB::tbb)
 endif()
 
 deploy_qt(${PROJECT_NAME})


### PR DESCRIPTION
- Fixed to specify BUNDLE DESTINATION
- TBB import library name was wrong

tested this CMakeLists.txt also on Debian.

----

・qt5/quazipはhomebrewでokです。

・どういうわけかclangだと`<execution>`がincludeできなかったため[^1]、以下のようにビルドする必要がありました。

```
cmake .. -DCMAKE_PREFIX_PATH=$(brew --prefix qt5) -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER=gcc-11
```

・ビルド後、SlackLogViewer.app/Contents/Info.plistを開き、手動で以下を書き加える必要があります。これの自動化については有識者にお願いしたいと思います。。

```
        <key>NSHighResolutionCapable</key>
        <true/>
```

----

・dylib(so)依存関係がひどいためバイナリは出せる状況にないです
・なお拙環境はi386 archを残すため(サポートの切れた)macOS Mojaveであることを申し添えます。`<execution>`の問題は最新のclangでは直っているのかもしれませんが検証できません。

[^1]: `SlackLogViewer/SlackLogViewer/SearchResultList.cpp:16:10: fatal error: 'execution' file not found
#include <execution>
         ^~~~~~~~~~~
1 error generated.`